### PR TITLE
Update haproxy-lkl.sh (#19)

### DIFF
--- a/ovz-bbr/bin/haproxy-lkl.sh
+++ b/ovz-bbr/bin/haproxy-lkl.sh
@@ -189,7 +189,7 @@ generate_config() {
 	    timeout client 30s
 	    timeout server 30s
 	backend local
-	    server srv 10.0.0.1
+	    server srv 10.0.0.1 send-proxy
 	EOF
 
 	local legal_rules=


### PR DESCRIPTION
增加原始IP给后端服务器
nginx需要增加proxy_protocol
如：listen 443 ssl http2 proxy_protocol;
以及：
set_real_ip_from 10.0.0.2;
real_ip_header proxy_protocol;

博客原文：https://wbuntu.com/p/1176
nginx文档代理相关：https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/